### PR TITLE
Add NLB component wrapper

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   test:
-    uses: cloudposse-terraform-components/.github/.github/workflows/shared-terraform-chatops.yml@merge-queue
+    uses: cloudposse-terraform-components/.github/.github/workflows/shared-terraform-chatops.yml@main
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/terratest') }}
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 
 <!-- markdownlint-disable -->
-<a href="https://cpco.io/homepage"><img src="https://github.com/cloudposse-terraform-components/template/blob/main/.github/banner.png?raw=true" alt="Project Banner"/></a><br/>
+<a href="https://cpco.io/homepage"><img src="https://github.com/cloudposse-terraform-components/aws-nlb/blob/main/.github/banner.png?raw=true" alt="Project Banner"/></a><br/>
     <p align="right">
-<a href="https://github.com/cloudposse-terraform-components/template/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-terraform-components/template.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a></p>
+<a href="https://github.com/cloudposse-terraform-components/aws-nlb/releases/latest"><img src="https://img.shields.io/github/release/cloudposse-terraform-components/aws-nlb.svg?style=for-the-badge" alt="Latest Release"/></a><a href="https://slack.cloudposse.com"><img src="https://slack.cloudposse.com/for-the-badge.svg" alt="Slack Community"/></a></p>
 <!-- markdownlint-restore -->
 
 <!--
@@ -27,7 +27,8 @@
 
 -->
 
-Description of this component 55
+Terraform component that wraps the [cloudposse/nlb/aws](https://github.com/cloudposse/terraform-aws-nlb) module.
+It provides a Network Load Balancer with optional listeners and target groups.
 
 
 > [!TIP]
@@ -47,16 +48,18 @@ Description of this component 55
 
 ## Usage
 
-**Stack Level**: Regional or Global
-
-Here's an example snippet for how to use this component.
+**Stack Level**: Regional
 
 ```yaml
 components:
   terraform:
-    foo:
+    nlb/basic:
       vars:
         enabled: true
+        vpc_id: "vpc-xxxxxxxx"
+        subnet_ids:
+          - "subnet-11111111"
+          - "subnet-22222222"
 ```
 
 > [!IMPORTANT]
@@ -72,56 +75,7 @@ components:
 
 
 
-<!-- markdownlint-disable -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-
-## Providers
-
-No providers.
-
-## Modules
-
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-
-## Resources
-
-No resources.
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
-| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
-| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
-| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
-| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
-| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="output_mock"></a> [mock](#output\_mock) | Mock output example for the Cloud Posse Terraform component template |
-<!-- markdownlint-restore -->
+# Terraform Module
 
 
 ## Related Projects
@@ -150,12 +104,12 @@ For additional context, refer to some of these links.
 > ✅ Your team owns everything.<br/>
 > ✅ 100% Open Source and backed by fanatical support.<br/>
 >
-> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-nlb&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
 > <details><summary>📚 <strong>Learn More</strong></summary>
 >
 > <br/>
 >
-> Cloud Posse is the leading [**DevOps Accelerator**](https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support) for funded startups and enterprises.
+> Cloud Posse is the leading [**DevOps Accelerator**](https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-nlb&utm_content=commercial_support) for funded startups and enterprises.
 >
 > *Your team can operate like a pro today.*
 >
@@ -167,7 +121,7 @@ For additional context, refer to some of these links.
 > - **Security Baseline.** Establish a secure environment from the start, with built-in governance, accountability, and comprehensive audit logs, safeguarding your operations.
 > - **GitOps.** Empower your team to manage infrastructure changes confidently and efficiently through Pull Requests, leveraging the full power of GitHub Actions.
 >
-> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-nlb&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
 >
 > #### Day-2: Your Operational Mastery
 > - **Training.** Equip your team with the knowledge and skills to confidently manage the infrastructure, ensuring long-term success and self-sufficiency.
@@ -178,7 +132,7 @@ For additional context, refer to some of these links.
 > - **Migration Assistance.** Accelerate your migration process with our dedicated support, minimizing disruption and speeding up time-to-value.
 > - **Customer Workshops.** Engage with our team in weekly workshops, gaining insights and strategies to continuously improve and innovate.
 >
-> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
+> <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-nlb&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
 > </details>
 
 ## ✨ Contributing
@@ -189,14 +143,14 @@ This project is under active development, and we encourage contributions from ou
 
 Many thanks to our outstanding contributors:
 
-<a href="https://github.com/cloudposse-terraform-components/template/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cloudposse-terraform-components/template&max=24" />
+<a href="https://github.com/cloudposse-terraform-components/aws-nlb/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cloudposse-terraform-components/aws-nlb&max=24" />
 </a>
 
-For 🐛 bug reports & feature requests, please use the [issue tracker](https://github.com/cloudposse-terraform-components/template/issues).
+For 🐛 bug reports & feature requests, please use the [issue tracker](https://github.com/cloudposse-terraform-components/aws-nlb/issues).
 
 In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
- 1. Review our [Code of Conduct](https://github.com/cloudposse-terraform-components/template/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
+ 1. Review our [Code of Conduct](https://github.com/cloudposse-terraform-components/aws-nlb/?tab=coc-ov-file#code-of-conduct) and [Contributor Guidelines](https://github.com/cloudposse/.github/blob/main/CONTRIBUTING.md).
  2. **Fork** the repo on GitHub
  3. **Clone** the project to your own machine
  4. **Commit** changes to your own branch
@@ -207,16 +161,16 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ### 🌎 Slack Community
 
-Join our [Open Source Community](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=slack) on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+Join our [Open Source Community](https://cpco.io/slack?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-nlb&utm_content=slack) on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
 
 ### 📰 Newsletter
 
-Sign up for [our newsletter](https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=newsletter) and join 3,000+ DevOps engineers, CTOs, and founders who get insider access to the latest DevOps trends, so you can always stay in the know.
+Sign up for [our newsletter](https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-nlb&utm_content=newsletter) and join 3,000+ DevOps engineers, CTOs, and founders who get insider access to the latest DevOps trends, so you can always stay in the know.
 Dropped straight into your Inbox every week — and usually a 5-minute read.
 
-### 📆 Office Hours <a href="https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=office_hours"><img src="https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png" align="right" /></a>
+### 📆 Office Hours <a href="https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-nlb&utm_content=office_hours"><img src="https://img.cloudposse.com/fit-in/200x200/https://cloudposse.com/wp-content/uploads/2019/08/Powered-by-Zoom.png" align="right" /></a>
 
-[Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
+[Join us every Wednesday via Zoom](https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-nlb&utm_content=office_hours) for your weekly dose of insider DevOps trends, AWS news and Terraform insights, all sourced from our SweetOps community, plus a _live Q&A_ that you can’t find anywhere else.
 It's **FREE** for everyone!
 ## License
 
@@ -258,57 +212,6 @@ All other trademarks referenced herein are the property of their respective owne
 Copyright © 2017-2025 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
-<a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/template&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
+<a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-nlb&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
 
-<img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse-terraform-components/template?pixel&cs=github&cm=readme&an=template"/>
-
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-
-## Providers
-
-No providers.
-
-## Modules
-
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
-
-## Resources
-
-No resources.
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
-| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br/>See description of individual variables for details.<br/>Leave string and numeric variables as `null` to use default value.<br/>Individual variable settings (non-null) override settings in context object,<br/>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br/>  "additional_tag_map": {},<br/>  "attributes": [],<br/>  "delimiter": null,<br/>  "descriptor_formats": {},<br/>  "enabled": true,<br/>  "environment": null,<br/>  "id_length_limit": null,<br/>  "label_key_case": null,<br/>  "label_order": [],<br/>  "label_value_case": null,<br/>  "labels_as_tags": [<br/>    "unset"<br/>  ],<br/>  "name": null,<br/>  "namespace": null,<br/>  "regex_replace_chars": null,<br/>  "stage": null,<br/>  "tags": {},<br/>  "tenant": null<br/>}</pre> | no |
-| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between ID elements.<br/>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
-| <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
-| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
-| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
-| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
-| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
-| <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
-| <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
-| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
-| <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="output_mock"></a> [mock](#output\_mock) | Mock output example for the Cloud Posse Terraform component template |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse-terraform-components/aws-nlb?pixel&cs=github&cm=readme&an=aws-nlb"/>

--- a/README.yaml
+++ b/README.yaml
@@ -1,56 +1,44 @@
-name: "template"
+name: "aws-nlb"
 
-# Canonical GitHub repo
-github_repo: "cloudposse-terraform-components/template"
+github_repo: "cloudposse-terraform-components/aws-nlb"
 
-# Short description of this project
 description: |-
-  Description of this component 55
+  Terraform component that wraps the [cloudposse/nlb/aws](https://github.com/cloudposse/terraform-aws-nlb) module.
+  It provides a Network Load Balancer with optional listeners and target groups.
 
 usage: |-
-  **Stack Level**: Regional or Global
-
-  Here's an example snippet for how to use this component.
+  **Stack Level**: Regional
 
   ```yaml
   components:
     terraform:
-      foo:
+      nlb/basic:
         vars:
           enabled: true
+          vpc_id: "vpc-xxxxxxxx"
+          subnet_ids:
+            - "subnet-11111111"
+            - "subnet-22222222"
   ```
-
-
-
-
 
 include:
   - "docs/terraform.md"
 
 tags:
   - terraform
-  - terraform-modules
   - aws
   - components
   - terraform-components
-  - root
-  - geodesic
-  - reference-implementation
-  - reference-architecture
 
-# Categories of this project
 categories:
-  - terraform-modules/root
   - terraform-components
 
-# License of this project
 license: "APACHE2"
 
-# Badges to display
 badges:
   - name: "Latest Release"
-    image: "https://img.shields.io/github/release/cloudposse-terraform-components/template.svg?style=for-the-badge"
-    url: "https://github.com/cloudposse-terraform-components/template/releases/latest"
+    image: "https://img.shields.io/github/release/cloudposse-terraform-components/aws-nlb.svg?style=for-the-badge"
+    url: "https://github.com/cloudposse-terraform-components/aws-nlb/releases/latest"
   - name: "Slack Community"
     image: "https://slack.cloudposse.com/for-the-badge.svg"
     url: "https://slack.cloudposse.com"
@@ -64,15 +52,11 @@ references:
     url: "https://cloudposse.com/"
 
 related:
-- name: "Cloud Posse Terraform Modules"
-  description: Our collection of reusable Terraform modules used by our reference architectures.
-  url: "https://docs.cloudposse.com/modules/"
-- name: "Atmos"
-  description: "Atmos is like docker-compose but for your infrastructure"
-  url: "https://atmos.tools"
+  - name: "Cloud Posse Terraform Modules"
+    description: Our collection of reusable Terraform modules used by our reference architectures.
+    url: "https://docs.cloudposse.com/modules/"
+  - name: "Atmos"
+    description: "Atmos is like docker-compose but for your infrastructure"
+    url: "https://atmos.tools"
 
-contributors: [] # If included generates contribs
-
-
-
-
+contributors: []

--- a/README.yaml
+++ b/README.yaml
@@ -15,6 +15,19 @@ usage: |-
       nlb/basic:
         vars:
           enabled: true
+          name: "nlb"
+          # internal: false # default value
+  ```
+
+  Example passing in a VPC ID and subnets.
+
+  ```yaml
+  components:
+    terraform:
+      nlb/basic:
+        vars:
+          enabled: true
+          name: "nlb"
           vpc_id: "vpc-xxxxxxxx"
           subnet_ids:
             - "subnet-11111111"

--- a/src/main.tf
+++ b/src/main.tf
@@ -2,4 +2,40 @@ locals {
   enabled = module.this.enabled
 }
 
+module "nlb" {
+  source  = "cloudposse/nlb/aws"
+  version = "0.18.2"
 
+  enabled = local.enabled
+
+  vpc_id                        = var.vpc_id
+  subnet_ids                    = var.subnet_ids
+  security_group_ids            = var.security_group_ids
+  internal                      = var.internal
+  load_balancer_name            = var.load_balancer_name
+  load_balancer_name_max_length = var.load_balancer_name_max_length
+  subnet_mapping_enabled        = var.subnet_mapping_enabled
+  eip_allocation_ids            = var.eip_allocation_ids
+
+  target_group_enabled              = var.target_group_enabled
+  target_group_name                 = var.target_group_name
+  target_group_name_max_length      = var.target_group_name_max_length
+  target_group_port                 = var.target_group_port
+  target_group_target_type          = var.target_group_target_type
+  target_group_ip_address_type      = var.target_group_ip_address_type
+  tcp_port                          = var.tcp_port
+  tcp_enabled                       = var.tcp_enabled
+  tls_enabled                       = var.tls_enabled
+  tls_port                          = var.tls_port
+  certificate_arn                   = var.certificate_arn
+  udp_enabled                       = var.udp_enabled
+  udp_port                          = var.udp_port
+  cross_zone_load_balancing_enabled = var.cross_zone_load_balancing_enabled
+  deletion_protection_enabled       = var.deletion_protection_enabled
+  deregistration_delay              = var.deregistration_delay
+  health_check_enabled              = var.health_check_enabled
+  health_check_port                 = var.health_check_port
+  stickiness_enabled                = var.stickiness_enabled
+
+  context = module.this.context
+}

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,4 +1,34 @@
-output "mock" {
-  description = "Mock output example for the Cloud Posse Terraform component template"
-  value       = local.enabled ? "hello ${basename(abspath(path.module))}" : ""
+output "nlb_name" {
+  description = "Name of the NLB"
+  value       = module.nlb.nlb_name
+}
+
+output "nlb_arn" {
+  description = "ARN of the NLB"
+  value       = module.nlb.nlb_arn
+}
+
+output "nlb_dns_name" {
+  description = "DNS name of the NLB"
+  value       = module.nlb.nlb_dns_name
+}
+
+output "nlb_zone_id" {
+  description = "Canonical hosted zone ID for the NLB"
+  value       = module.nlb.nlb_zone_id
+}
+
+output "security_group_id" {
+  description = "Security group ID created for the NLB"
+  value       = module.nlb.security_group_id
+}
+
+output "default_listener_arn" {
+  description = "ARN of the default listener"
+  value       = module.nlb.default_listener_arn
+}
+
+output "default_target_group_arn" {
+  description = "ARN of the default target group"
+  value       = module.nlb.default_target_group_arn
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,34 +1,4 @@
-output "nlb_name" {
-  description = "Name of the NLB"
-  value       = module.nlb.nlb_name
-}
-
-output "nlb_arn" {
-  description = "ARN of the NLB"
-  value       = module.nlb.nlb_arn
-}
-
-output "nlb_dns_name" {
-  description = "DNS name of the NLB"
-  value       = module.nlb.nlb_dns_name
-}
-
-output "nlb_zone_id" {
-  description = "Canonical hosted zone ID for the NLB"
-  value       = module.nlb.nlb_zone_id
-}
-
-output "security_group_id" {
-  description = "Security group ID created for the NLB"
-  value       = module.nlb.security_group_id
-}
-
-output "default_listener_arn" {
-  description = "ARN of the default listener"
-  value       = module.nlb.default_listener_arn
-}
-
-output "default_target_group_arn" {
-  description = "ARN of the default target group"
-  value       = module.nlb.default_target_group_arn
+output "nlb" {
+  description = "The NLB of the Component"
+  value       = module.nlb
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,0 +1,29 @@
+provider "aws" {
+  region = var.region
+
+  profile = module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
+
+  dynamic "assume_role" {
+    for_each = module.iam_roles.profiles_enabled ? [] : ["role"]
+    content {
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
+    }
+  }
+}
+
+module "iam_roles" {
+  source  = "../account-map/modules/iam-roles"
+  context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+variable "import_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM Role ARN to use when importing a resource"
+}

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,0 +1,48 @@
+module "vpc" {
+  count = local.enabled && var.vpc_id == null ? 1 : 0
+
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.8.0"
+
+  component = var.vpc_component_name
+
+  context = module.this.context
+}
+
+module "dns_delegated" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.8.0"
+
+  component   = var.dns_delegated_component_name
+  environment = coalesce(var.dns_delegated_environment_name, module.iam_roles.global_environment_name)
+
+  bypass = var.dns_acm_enabled
+
+  # Ignore errors if component doesn't exist
+  ignore_errors = true
+
+  defaults = {
+    default_domain_name = ""
+    certificate         = {}
+  }
+
+  context = module.this.context
+}
+
+module "acm" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.8.0"
+
+  component = var.acm_component_name
+
+  bypass = !var.dns_acm_enabled
+
+  # Ignore errors if component doesn't exist
+  ignore_errors = true
+
+  defaults = {
+    arn = ""
+  }
+
+  context = module.this.context
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -1,11 +1,18 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
 variable "vpc_id" {
   type        = string
   description = "VPC ID to associate with NLB"
+  default     = null
 }
 
 variable "subnet_ids" {
   type        = list(string)
   description = "List of subnet IDs to associate with NLB"
+  default     = null
 }
 
 variable "security_group_ids" {
@@ -106,7 +113,7 @@ variable "tls_port" {
 
 variable "certificate_arn" {
   type        = string
-  default     = ""
+  default     = null
   description = "ARN of the certificate for the TLS listener"
 }
 
@@ -156,4 +163,34 @@ variable "stickiness_enabled" {
   type        = bool
   default     = false
   description = "Enable stickiness on the default target group"
+}
+
+variable "vpc_component_name" {
+  type        = string
+  description = "Name of the VPC component"
+  default     = "vpc"
+}
+
+variable "dns_delegated_component_name" {
+  type        = string
+  default     = "dns-delegated"
+  description = "Atmos `dns-delegated` component name"
+}
+
+variable "dns_delegated_environment_name" {
+  type        = string
+  default     = null
+  description = "`dns-delegated` component environment name"
+}
+
+variable "acm_component_name" {
+  type        = string
+  default     = "acm"
+  description = "Atmos `acm` component name"
+}
+
+variable "dns_acm_enabled" {
+  type        = bool
+  default     = false
+  description = "If `true`, use the ACM ARN created by the given `dns-delegated` component. Otherwise, use the ACM ARN created by the given `acm` component. Overridden by `certificate_arn`"
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -1,0 +1,159 @@
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID to associate with NLB"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of subnet IDs to associate with NLB"
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "Additional security group IDs to allow access to the NLB"
+}
+
+variable "internal" {
+  type        = bool
+  default     = false
+  description = "Whether the NLB is internal"
+}
+
+variable "load_balancer_name" {
+  type        = string
+  default     = ""
+  description = "Name for the load balancer"
+}
+
+variable "load_balancer_name_max_length" {
+  type        = number
+  default     = 32
+  description = "Max length for the load balancer name"
+}
+
+variable "subnet_mapping_enabled" {
+  type        = bool
+  default     = false
+  description = "Create EIPs for the provided subnet IDs"
+}
+
+variable "eip_allocation_ids" {
+  type        = list(string)
+  default     = []
+  description = "Allocation IDs for EIPs when subnet mapping is enabled"
+}
+
+variable "target_group_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether to create the default target group and listener"
+}
+
+variable "target_group_name" {
+  type        = string
+  default     = ""
+  description = "Name of the default target group"
+}
+
+variable "target_group_name_max_length" {
+  type        = number
+  default     = 32
+  description = "Max length for the target group name"
+}
+
+variable "target_group_port" {
+  type        = number
+  default     = 80
+  description = "Port for the default target group"
+}
+
+variable "target_group_target_type" {
+  type        = string
+  default     = "ip"
+  description = "Target type for the default target group"
+}
+
+variable "target_group_ip_address_type" {
+  type        = string
+  default     = "ipv4"
+  description = "IP address type for the target group"
+}
+
+variable "tcp_port" {
+  type        = number
+  default     = 80
+  description = "Port for the TCP listener"
+}
+
+variable "tcp_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable the TCP listener"
+}
+
+variable "tls_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable the TLS listener"
+}
+
+variable "tls_port" {
+  type        = number
+  default     = 443
+  description = "Port for the TLS listener"
+}
+
+variable "certificate_arn" {
+  type        = string
+  default     = ""
+  description = "ARN of the certificate for the TLS listener"
+}
+
+variable "udp_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable the UDP listener"
+}
+
+variable "udp_port" {
+  type        = number
+  default     = 53
+  description = "Port for the UDP listener"
+}
+
+variable "cross_zone_load_balancing_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable cross zone load balancing"
+}
+
+variable "deletion_protection_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable deletion protection for the NLB"
+}
+
+variable "deregistration_delay" {
+  type        = number
+  default     = 15
+  description = "Time to wait before deregistering targets"
+}
+
+variable "health_check_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable health checks"
+}
+
+variable "health_check_port" {
+  type        = number
+  default     = null
+  description = "Port for health checks"
+}
+
+variable "stickiness_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable stickiness on the default target group"
+}

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -1,5 +1,10 @@
 terraform {
   required_version = ">= 1.0.0"
 
-  required_providers {}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
 }

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -12,7 +12,7 @@ type ComponentSuite struct {
 }
 
 func (s *ComponentSuite) TestBasic() {
-	const component = "example/basic"
+	const component = "nlb/basic"
 	const stack = "default-test"
 	const awsRegion = "us-east-2"
 
@@ -23,9 +23,8 @@ func (s *ComponentSuite) TestBasic() {
 	s.DriftTest(component, stack, nil)
 }
 
-
 func (s *ComponentSuite) TestEnabledFlag() {
-	const component = "example/disabled"
+	const component = "nlb/disabled"
 	const stack = "default-test"
 	s.VerifyEnabledFlag(component, stack, nil)
 }

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -1,9 +1,12 @@
 package test
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/cloudposse/test-helpers/pkg/atmos"
 	helper "github.com/cloudposse/test-helpers/pkg/atmos/component-helper"
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,9 +23,25 @@ func (s *ComponentSuite) TestBasic() {
 	options, _ := s.DeployAtmosComponent(s.T(), component, stack, nil)
 	assert.NotNil(s.T(), options)
 
+	nlb_name := atmos.Output(s.T(), options, "nlb.nlb_name")
+	assert.True(s.T(), strings.HasPrefix(nlb_name, "eg-default-ue2-test-"))
+
 	s.DriftTest(component, stack, nil)
 }
+func (s *ComponentSuite) TestAcm() {
+	const component = "nlb/acm"
+	const stack = "default-test"
+	const awsRegion = "us-east-2"
 
+	defer s.DestroyAtmosComponent(s.T(), component, stack, nil)
+	options, _ := s.DeployAtmosComponent(s.T(), component, stack, nil)
+
+	assert.NotNil(s.T(), options)
+
+	nlb_name := atmos.Output(s.T(), options, "nlb.nlb_name")
+	assert.True(s.T(), strings.HasPrefix(nlb_name, "eg-default-ue2-test-"))
+
+}
 func (s *ComponentSuite) TestEnabledFlag() {
 	const component = "nlb/disabled"
 	const stack = "default-test"
@@ -31,5 +50,17 @@ func (s *ComponentSuite) TestEnabledFlag() {
 
 func TestRunSuite(t *testing.T) {
 	suite := new(ComponentSuite)
+	suite.AddDependency(t, "vpc", "default-test", nil)
+	subdomain := strings.ToLower(random.UniqueId())
+	inputs := map[string]interface{}{
+		"zone_config": []map[string]interface{}{
+			{
+				"subdomain": subdomain,
+				"zone_name": "components.cptest.test-automation.app",
+			},
+		},
+	}
+	suite.AddDependency(t, "dns-delegated", "default-test", &inputs)
+	suite.AddDependency(t, "acm", "default-test", nil)
 	helper.Run(t, suite)
 }

--- a/test/fixtures/stacks/catalog/usecase/basic-acm.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic-acm.yaml
@@ -1,6 +1,6 @@
 components:
   terraform:
-    nlb/basic:
+    nlb/acm:
       metadata:
         component: target
       vars:

--- a/test/fixtures/stacks/catalog/usecase/basic-dns-delegated.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic-dns-delegated.yaml
@@ -1,8 +1,9 @@
 components:
   terraform:
-    nlb/basic:
+    nlb/dns-delegated:
       metadata:
         component: target
       vars:
         enabled: true
+        dns_acm_enabled: true
         

--- a/test/fixtures/stacks/catalog/usecase/basic.yaml
+++ b/test/fixtures/stacks/catalog/usecase/basic.yaml
@@ -1,7 +1,7 @@
 components:
   terraform:
-    example/basic:
+    nlb/basic:
       metadata:
         component: target
       vars:
-        enabled: true
+        enabled: false

--- a/test/fixtures/stacks/catalog/usecase/disabled.yaml
+++ b/test/fixtures/stacks/catalog/usecase/disabled.yaml
@@ -1,6 +1,6 @@
 components:
   terraform:
-    example/disabled:
+    nlb/disabled:
       metadata:
         component: target
       vars:

--- a/test/fixtures/stacks/catalog/vpc.yaml
+++ b/test/fixtures/stacks/catalog/vpc.yaml
@@ -1,0 +1,19 @@
+components:
+  terraform:
+    vpc:
+      metadata:
+        component: vpc
+      vars:
+        name: "vpc"
+        availability_zones:
+          - "b"
+          - "c"
+        public_subnets_enabled: true
+        max_nats: 1
+        # Private subnets do not need internet access
+        nat_gateway_enabled: false
+        nat_instance_enabled: false
+        subnet_type_tag_key: "eg.cptest.co/subnet/type"
+        max_subnet_count: 3
+        vpc_flow_logs_enabled: false
+        ipv4_primary_cidr_block: "172.17.0.0/16"

--- a/test/fixtures/stacks/orgs/default/test/tests.yaml
+++ b/test/fixtures/stacks/orgs/default/test/tests.yaml
@@ -1,4 +1,5 @@
 import:
   - orgs/default/test/_defaults
+  - catalog/vpc
   - catalog/usecase/basic
   - catalog/usecase/disabled

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -15,5 +15,17 @@ spec:
         - "**/**"
       excluded_paths: []
 
+    - component: "vpc"
+      source: github.com/cloudposse-terraform-components/aws-vpc.git//src?ref={{.Version}}
+      version: v1.536.0
+      targets:
+        - "components/terraform/vpc"
+      included_paths:
+        - "**/*.tf"
+        - "**/*.md"
+        - "**/*.tftmpl"
+        - "**/modules/**"
+      excluded_paths: []
+
 
 


### PR DESCRIPTION
## Summary
- implement wrapper for `cloudposse/nlb/aws` module
- document component and usage
- add passthrough variables
- update tests and fixtures for new component
- vendor VPC for test support

## Testing
- `terraform fmt -recursive src`
- `go mod tidy`
- `go test -run TestRunSuite -v ./...` *(fails: no EC2 IMDS role)*

------
https://chatgpt.com/codex/tasks/task_b_6876769410e8832b998a2b069bdeaa54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable AWS Network Load Balancer (NLB) Terraform component with support for listeners, target groups, and advanced options such as cross-zone load balancing, deletion protection, health checks, and stickiness.
  * Added outputs for key NLB attributes including name, ARN, DNS name, zone ID, security group, and listener/target group ARNs.
  * Added support for DNS delegated certificate handling and conditional TLS listener configuration.
  * Included AWS provider setup with flexible profile or assume-role authentication.
  * Added remote state modules for VPC, DNS delegation, and ACM components to integrate dependencies.

* **Documentation**
  * Updated all documentation and metadata to reference the new aws-nlb component, replacing template references.
  * Improved usage examples and component descriptions for clarity and accuracy.

* **Tests**
  * Updated test cases and stack fixtures to use the new aws-nlb component paths and naming.
  * Added new tests for ACM integration and extended test suite dependencies.

* **Chores**
  * Added a vendoring manifest entry for the VPC component dependency.
  * Specified required AWS provider version in the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->