### PR TITLE
chore: upgrade remote-state to v2.0.0

### DIFF
--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -2,7 +2,7 @@ module "vpc" {
   count = local.enabled && var.vpc_id == null ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = var.vpc_component_name
 
@@ -11,7 +11,7 @@ module "vpc" {
 
 module "dns_delegated" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = var.dns_delegated_component_name
   environment = coalesce(var.dns_delegated_environment_name, module.iam_roles.global_environment_name)
@@ -31,7 +31,7 @@ module "dns_delegated" {
 
 module "acm" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component = var.acm_component_name
 

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.0"
     }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 2.0.0, < 3.0.0"
+    }
   }
 }

--- a/test/fixtures/vendor.yaml
+++ b/test/fixtures/vendor.yaml
@@ -8,7 +8,7 @@ spec:
   sources:
     - component: "account-map"
       source: github.com/cloudposse-terraform-components/aws-account-map.git//src?ref={{.Version}}
-      version: 1.520.0
+      version: v1.537.2
       targets:
         - "components/terraform/account-map"
       included_paths:
@@ -56,7 +56,7 @@ spec:
 
     - component: "vpc"
       source: github.com/cloudposse-terraform-components/aws-vpc.git//src?ref={{.Version}}
-      version: v1.536.0
+      version: v2.1.2
       targets:
         - "components/terraform/vpc"
       included_paths:


### PR DESCRIPTION
## Summary
- Upgrade `cloudposse/stack-config/yaml//modules/remote-state` from v1.x to v2.0.0
- Add `cloudposse/utils` provider constraint `>= 2.0.0, < 3.0.0`
- Update vendored dependency versions to releases with remote-state v2.0.0

## Changes
- `src/remote-state.tf`: version pin `1.8.0`/`1.5.0` → `2.0.0`
- `src/versions.tf`: add/update utils provider constraint
- `test/fixtures/vendor.yaml`: update account-map + dep versions

## Test plan
- [ ] CI lint passes (terraform init, no provider conflicts)
- [ ] Terratest passes in merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)